### PR TITLE
feat(mock-data):reconcept gen data fk table.[MDA-007]

### DIFF
--- a/go/core/logger/logger.go
+++ b/go/core/logger/logger.go
@@ -156,6 +156,10 @@ func (p Pathfinder) ErrorContext(ctx context.Context, msg string, fields ...any)
 	slog.ErrorContext(ctx, fmt.Sprintf("[service][%s] %s", p.svc, msg), fields...)
 }
 
+func (p Pathfinder) DebugContext(ctx context.Context, msg string, fields ...any) {
+	slog.DebugContext(ctx, fmt.Sprintf("[service][%s] %s", p.svc, msg), fields...)
+}
+
 func (p Pathfinder) NewPathfinder(svc string) Pathfinder {
 	return Pathfinder{svc: p.svc + "." + svc}
 }

--- a/go/internal/model/generate_mock_data_model.go
+++ b/go/internal/model/generate_mock_data_model.go
@@ -1,10 +1,10 @@
 package model
 
+// GenerateMockDataWithTableResponse is the response struct for the GenerateMockDataWithTable API
 type GenerateMockDataWithOneTableRequest struct {
 	TableName string `json:"table_name"`
 	NumSample int    `json:"num_samples" validate:"true"`
 }
-
 type GenerateMockDataWithOneTableResponseData struct {
 	Query            string  `json:"query"`
 	PromptTokens     int     `json:"prompt_tokens"`
@@ -12,8 +12,24 @@ type GenerateMockDataWithOneTableResponseData struct {
 	TotalTokens      int     `json:"total_tokens"`
 	TimeTaken        float64 `json:"time_taken"`
 }
-
 type GenerateMockDataWithOneTableResponse struct {
 	Status int                                      `json:"status"`
 	Data   GenerateMockDataWithOneTableResponseData `json:"data"`
+}
+
+// GenerateMockDataWithFkTableResponse is the response struct for the GenerateMockDataWithFkTable API
+type GenerateMockDataWithFkTableRequest struct {
+	TableName string `json:"table_name"`
+	NumSample int    `json:"num_samples" validate:"true"`
+}
+type GenerateMockDataWithFkTableResponseData struct {
+	Query            string  `json:"query"`
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	TotalTokens      int     `json:"total_tokens"`
+	TimeTaken        float64 `json:"time_taken"`
+}
+type GenerateMockDataWithFkTableResponse struct {
+	Status int                                     `json:"status"`
+	Data   GenerateMockDataWithFkTableResponseData `json:"data"`
 }

--- a/go/internal/server/route.go
+++ b/go/internal/server/route.go
@@ -42,5 +42,12 @@ func registerRoute(service service.Service) http.Handler {
 				service.GenerateMockDataService.GenerateMockDataWithOneTable,
 			)))
 
+	r.Post("/v1/mock-data/with-fk",
+		httpserver.NewTransport(
+			&model.GenerateMockDataWithFkTableRequest{},
+			httpserver.NewEndpoint(
+				service.GenerateMockDataService.GenerateMockDataWithFkTables,
+			)))
+
 	return mux
 }

--- a/go/internal/service/generate_mock_data_service.go
+++ b/go/internal/service/generate_mock_data_service.go
@@ -10,10 +10,12 @@ import (
 	"github.com/pawatOrbit/ai-mock-data-service/go/core/exception"
 	"github.com/pawatOrbit/ai-mock-data-service/go/core/httpclient"
 	"github.com/pawatOrbit/ai-mock-data-service/go/core/httpclient/completions"
+	"github.com/pawatOrbit/ai-mock-data-service/go/core/logger"
 	"github.com/pawatOrbit/ai-mock-data-service/go/core/validation"
 	"github.com/pawatOrbit/ai-mock-data-service/go/internal/model"
 	"github.com/pawatOrbit/ai-mock-data-service/go/internal/repository"
 	"github.com/pawatOrbit/ai-mock-data-service/go/utils"
+	"github.com/pawatOrbit/ai-mock-data-service/go/utils/conv"
 )
 
 const (
@@ -22,6 +24,7 @@ const (
 
 type GenerateMockDataService interface {
 	GenerateMockDataWithOneTable(ctx context.Context, in *model.GenerateMockDataWithOneTableRequest) (*model.GenerateMockDataWithOneTableResponse, error)
+	GenerateMockDataWithFkTables(ctx context.Context, in *model.GenerateMockDataWithFkTableRequest) (*model.GenerateMockDataWithFkTableResponse, error)
 }
 
 type generateMockDataService struct {
@@ -89,4 +92,148 @@ func (g *generateMockDataService) GenerateMockDataWithOneTable(ctx context.Conte
 	}
 
 	return resp, nil
+}
+
+func (g *generateMockDataService) GenerateMockDataWithFkTables(ctx context.Context, in *model.GenerateMockDataWithFkTableRequest) (*model.GenerateMockDataWithFkTableResponse, error) {
+	errValidate := validation.ValidateStruct(in)
+	if errValidate != nil {
+		return nil, g.Errors.ErrInvalidRequest.WithDebugMessage(errValidate.Error())
+	}
+
+	slog := logger.NewPathfinder("GenerateMockDataWithFkTables")
+
+	dateTimeNow := time.Now()
+
+	PromptTokens := 0
+	CompletionTokens := 0
+	TotalTokens := 0
+
+	// Get table schema
+	tableSchema, err := g.Repo.TableSchemasRepository.GetDatabaseSchemaByTableName(ctx, in.TableName)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, g.Errors.ErrUnableToProceed.WithDebugMessage(err.Error())
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, g.Errors.ErrNotFound.WithDebugMessage("table not found")
+	}
+
+	extractKeyPrompt := g.Utils.GeneratePromptUtils.GeneratePromptForFKExtraction(tableSchema.TableName, tableSchema.TableScript.String)
+	reqGetCompletionsService := completions.CompletionRequest{
+		Model: g.Config.LMStudio.Model,
+		Messages: []completions.MessageRequest{
+			{
+				Role:    ROLE_LM_STUDIO,
+				Content: extractKeyPrompt,
+			},
+		},
+		Temperature: g.Config.LMStudio.Temperature,
+		MaxTokens:   g.Config.LMStudio.MaxTokens,
+	}
+
+	respKeyExtraction, err := g.LmStudioClient.GetCompletionsService.GetCompletionsService(ctx, reqGetCompletionsService)
+	if err != nil {
+		return nil, g.Errors.ErrUnableToProceed.WithDebugMessage(err.Error())
+	}
+
+	PromptTokens += respKeyExtraction.Usage.PromptTokens
+	CompletionTokens += respKeyExtraction.Usage.CompletionTokens
+	TotalTokens += respKeyExtraction.Usage.TotalTokens
+
+	_, fk := g.Utils.ExtractStringUtils.ExtractForeignKeyInfo(respKeyExtraction.Choices[0].Message.Content)
+
+	insertResponse := []string{}
+	fieldName := []string{}
+	fieldValue := []string{}
+
+	// index := 0
+	for fkKey, v := range fk {
+		fkTable := v[0]
+		fkField := v[1]
+
+		slog.DebugContext(ctx, "Foreign key", "fkKey", fkKey, "fkTable", fkTable, "fkField", fkField)
+
+		tableSchemaFk, err := g.Repo.TableSchemasRepository.GetDatabaseSchemaByTableName(ctx, fkTable)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return nil, g.Errors.ErrUnableToProceed.WithDebugMessage(err.Error())
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, g.Errors.ErrNotFound.WithDebugMessage("table not found")
+		}
+
+		extractKeyPrompt := g.Utils.GeneratePromptUtils.GeneratePromptWithoutKey(tableSchemaFk.TableName, tableSchemaFk.TableScript.String, 1)
+
+		reqGetCompletionsService := completions.CompletionRequest{
+			Model: g.Config.LMStudio.Model,
+			Messages: []completions.MessageRequest{
+				{
+					Role:    ROLE_LM_STUDIO,
+					Content: extractKeyPrompt,
+				},
+			},
+			Temperature: g.Config.LMStudio.Temperature,
+			MaxTokens:   g.Config.LMStudio.MaxTokens,
+		}
+
+		respFromFkTable, err := g.LmStudioClient.GetCompletionsService.GetCompletionsService(ctx, reqGetCompletionsService)
+		if err != nil {
+			return nil, g.Errors.ErrUnableToProceed.WithDebugMessage(err.Error())
+		}
+
+		PromptTokens += respFromFkTable.Usage.PromptTokens
+		CompletionTokens += respFromFkTable.Usage.CompletionTokens
+		TotalTokens += respFromFkTable.Usage.TotalTokens
+
+		responseFromFkTable := conv.ReplaceNewlineWithSpace(respFromFkTable.Choices[0].Message.Content)
+
+		insertResponse = append(insertResponse, responseFromFkTable)
+
+		insertValueAndField, err := g.Utils.ExtractStringUtils.ExtractInsertValues(responseFromFkTable)
+		if err != nil {
+			return nil, g.Errors.ErrUnableToProceed.WithDebugMessage(err.Error())
+		}
+		if len(insertValueAndField) == 0 {
+			return nil, g.Errors.ErrNotFound.WithDebugMessage("table not found")
+		}
+		fieldName = append(fieldName, fkKey)
+		fieldValue = append(fieldValue, insertValueAndField[fkField])
+
+	}
+
+	prompt := g.Utils.GeneratePromptUtils.GeneratePromptForMockDataWithValues(tableSchema.TableName, tableSchema.TableScript.String, in.NumSample, fieldName, fieldValue)
+	reqGetCompletionsMain := completions.CompletionRequest{
+		Model: g.Config.LMStudio.Model,
+		Messages: []completions.MessageRequest{
+			{
+				Role:    ROLE_LM_STUDIO,
+				Content: prompt,
+			},
+		},
+		Temperature: g.Config.LMStudio.Temperature,
+		MaxTokens:   g.Config.LMStudio.MaxTokens,
+	}
+
+	respMain, err := g.LmStudioClient.GetCompletionsService.GetCompletionsService(ctx, reqGetCompletionsMain)
+	if err != nil {
+		return nil, g.Errors.ErrUnableToProceed.WithDebugMessage(err.Error())
+	}
+
+	PromptTokens += respMain.Usage.PromptTokens
+	CompletionTokens += respMain.Usage.CompletionTokens
+	TotalTokens += respMain.Usage.TotalTokens
+
+	responseInsert := conv.ReplaceNewlineWithSpace(respMain.Choices[0].Message.Content) + " " + conv.JoinStringSlice(insertResponse, " ")
+
+	slog.DebugContext(ctx, "Response insert", "responseInsert", responseInsert)
+
+	return &model.GenerateMockDataWithFkTableResponse{
+		Status: 200,
+		Data: model.GenerateMockDataWithFkTableResponseData{
+			Query:            responseInsert,
+			PromptTokens:     PromptTokens,
+			CompletionTokens: CompletionTokens,
+			TotalTokens:      TotalTokens,
+			TimeTaken:        time.Since(dateTimeNow).Seconds(),
+		},
+	}, nil
+
 }

--- a/go/utils/conv/strings.go
+++ b/go/utils/conv/strings.go
@@ -1,0 +1,17 @@
+package conv
+
+import "strings"
+
+func JoinStringSlice(slice []string, sep string) string {
+	if len(slice) == 0 {
+		return ""
+	}
+	if len(slice) == 1 {
+		return slice[0]
+	}
+	return strings.Join(slice, sep)
+}
+
+func ReplaceNewlineWithSpace(input string) string {
+	return strings.ReplaceAll(input, "\n", " ")
+}


### PR DESCRIPTION
This pull request introduces a new feature for generating mock data with foreign key (FK) relationships, along with some utility and logging enhancements. The most significant changes include the addition of a new API endpoint, service logic, and utility functions to support FK-based mock data generation, as well as a new logging method.

### New Feature: Mock Data Generation with Foreign Keys
* Added `GenerateMockDataWithFkTableRequest`, `GenerateMockDataWithFkTableResponseData`, and `GenerateMockDataWithFkTableResponse` structs to support the new FK-based mock data generation API. (`go/internal/model/generate_mock_data_model.go`)
* Implemented `GenerateMockDataWithFkTables` method in `generateMockDataService` to handle FK-based mock data generation logic, including schema retrieval, FK extraction, and data generation using an external language model. (`go/internal/service/generate_mock_data_service.go`)
* Registered a new route `/v1/mock-data/with-fk` for the FK-based mock data generation API. (`go/internal/server/route.go`)

### Utility Enhancements
* Added `JoinStringSlice` and `ReplaceNewlineWithSpace` utility functions in the new `go/utils/conv/strings.go` file to handle string manipulations for combining and formatting responses. (`go/utils/conv/strings.go`)

### Logging Improvements
* Introduced a new `DebugContext` method in the `Pathfinder` logger to log debug-level messages with contextual information. (`go/core/logger/logger.go`)

### Service Updates
* Updated the `GenerateMockDataService` interface to include the new `GenerateMockDataWithFkTables` method. (`go/internal/service/generate_mock_data_service.go`)
* Added necessary imports for the new logger and utility functions. (`go/internal/service/generate_mock_data_service.go`)