### PR TITLE
fix(mock-data):fix if not found fk.[MDA-007]

### DIFF
--- a/go/utils/prompt/generate_prompt.go
+++ b/go/utils/prompt/generate_prompt.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 )
 
-type GeneratePromptUtils interface{
+type GeneratePromptUtils interface {
 	GeneratePromptWithoutKey(tableName, tableScript string, numSample int) string
 	GeneratePromptForFKExtraction(tableName, tableScript string) string
 	GeneratePromptForMockDataWithValues(tableName, tableScript string, numSample int, fieldsName, fieldsValue []string) string
-
 }
 
 type GeneratePromptUtilsImpl struct {
@@ -28,6 +27,7 @@ Table Structure:
 %s
 Please generate %d rows of mock data for this table. Ensure that the data is realistic and adheres to the structure defined above.
 Create mock data for all fields in the table without using functions like NOW() or UUID(). Use the following format:
+Please give me only the SQL insert statements in the following format and do not include any other text:
 Please do not think or describe, just provide the SQL insert statements in the following format:
 Example of format to use:
 uuid 'a5f89c0d-e4b2-46ae-8716-11431ddad3af', 'b2e7dcfa-e1ab-460a-8a5a-f9ce555d1234'


### PR DESCRIPTION
This pull request refactors the `generateMockDataService` to improve code reusability and enhance the clarity of generated SQL prompts. The changes include introducing a helper method for LLM calls, refactoring redundant code, and updating prompt generation instructions.

### Refactoring for Code Reusability:

* **Added `callLLM` helper method**: A new method `callLLM` was introduced to encapsulate the logic for making LLM calls, reducing redundancy across the service. (`go/internal/service/generate_mock_data_service.go`, [go/internal/service/generate_mock_data_service.goR97-R108](diffhunk://#diff-904846693a0625e484e3de28a801fd476fa6546635d86defb523084fe45d2d01R97-R108))
* **Replaced repetitive LLM call logic**: All instances of inline LLM call logic in `GenerateMockDataWithFkTables` were replaced with calls to the new `callLLM` method. (`go/internal/service/generate_mock_data_service.go`, [[1]](diffhunk://#diff-904846693a0625e484e3de28a801fd476fa6546635d86defb523084fe45d2d01L121-R133) [[2]](diffhunk://#diff-904846693a0625e484e3de28a801fd476fa6546635d86defb523084fe45d2d01L165-R188) [[3]](diffhunk://#diff-904846693a0625e484e3de28a801fd476fa6546635d86defb523084fe45d2d01L203-R214)

### Enhancements to Prompt Generation:

* **Improved handling for missing foreign keys**: Added logic to handle cases where no foreign keys are found by generating specific prompts and responses. (`go/internal/service/generate_mock_data_service.go`, [go/internal/service/generate_mock_data_service.goR143-R166](diffhunk://#diff-904846693a0625e484e3de28a801fd476fa6546635d86defb523084fe45d2d01R143-R166))
* **Updated prompt instructions**: Enhanced the SQL prompt template to explicitly request SQL insert statements without additional descriptive text. (`go/utils/prompt/generate_prompt.go`, [go/utils/prompt/generate_prompt.goR30](diffhunk://#diff-3d8e9a5e633704330d3dd0741f9cbb1d448586bc51603a46b68ce71124ec5fecR30))

### Cleanup:

* Removed unnecessary blank lines and trailing code artifacts for better readability. (`go/internal/service/generate_mock_data_service.go`, [[1]](diffhunk://#diff-904846693a0625e484e3de28a801fd476fa6546635d86defb523084fe45d2d01L238); `go/utils/prompt/generate_prompt.go`, [[2]](diffhunk://#diff-3d8e9a5e633704330d3dd0741f9cbb1d448586bc51603a46b68ce71124ec5fecL12)